### PR TITLE
Add prometheus monitoring

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -50,10 +50,11 @@ jobs:
           ansible-playbook ./ansible/playbooks/deploy.yml \
             --inventory ./ansible/inventory/nodes.yml \
             --limit node1 \
-            --extra-vars "IMAGE_TAG=${{ github.sha }} \
+            --key-file ~/.ssh/oci_private_key \
+            --verbose \
             --extra-vars "DOCKERHUB_ACCOUNT=${{ vars.DOCKERHUB_ACCOUNT }} \
-            --extra-vars "MKDOCS_APP_NAME=${{ vars.MKDOCS_APP_NAME }}" \
             --extra-vars "CF_ACCESS_CLIENT_ID=${{ secrets.CF_ACCESS_CLIENT_ID }}" \
             --extra-vars "CF_ACCESS_CLIENT_SECRET=${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
-            --key-file ~/.ssh/oci_private_key \
-            --verbose
+            --extra-vars "MKDOCS_APP_NAME=${{ vars.MKDOCS_APP_NAME }}" \
+            --extra-vars "APP_TAG=${{ github.sha }} \
+            --extra-vars "PROM_TAG=${{ vars.PROM_TAG }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -68,4 +68,4 @@ jobs:
             --extra-vars "GRAFANA_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}" \
             --extra-vars "GRAFANA_WORKDIR=/usr/share/grafana" \
             --extra-vars "GRAFANA_PROVISIONING_PATH=conf/provisioning" \
-            --extra-vars "GRAFANA_RESET=${{ inputs.GRAFANA_RESET }}
+            --extra-vars "GRAFANA_RESET=${{ inputs.GRAFANA_RESET }}"

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -57,4 +57,5 @@ jobs:
             --extra-vars "CF_ACCESS_CLIENT_SECRET=${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
             --extra-vars "MKDOCS_APP_NAME=${{ vars.MKDOCS_APP_NAME }}" \
             --extra-vars "APP_TAG=${{ github.sha }} \
-            --extra-vars "PROM_TAG=${{ vars.PROM_TAG }}
+            --extra-vars "PROM_TAG=${{ vars.PROM_TAG }} \
+            --extra-vars "GRAFANA_TAG=${{ vars.GRAFANA_TAG }}

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -64,8 +64,8 @@ jobs:
             --extra-vars "APP_TAG=${{ github.sha }} \
             --extra-vars "PROM_TAG=${{ vars.PROM_TAG }} \
             --extra-vars "GRAFANA_TAG=${{ vars.GRAFANA_TAG }} \
-            --extra-vars "GRAFANA_ADMIN_USER=${{ secrets.GF_SECURITY_ADMIN_USER }}" \
-            --extra-vars "GRAFANA_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}" \
+            --extra-vars "GRAFANA_ADMIN_USER=${{ secrets.GRAFANA_ADMIN_USER }}" \
+            --extra-vars "GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}" \
             --extra-vars "GRAFANA_WORKDIR=/usr/share/grafana" \
             --extra-vars "GRAFANA_PROVISIONING_PATH=conf/provisioning" \
             --extra-vars "GRAFANA_RESET=${{ inputs.GRAFANA_RESET }}"

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -2,6 +2,11 @@ name: Build Prod
 
 on:
   workflow_dispatch:
+    inputs:
+      GRAFANA_RESET:
+        description: "Reset Grafana"
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -58,4 +63,9 @@ jobs:
             --extra-vars "MKDOCS_APP_NAME=${{ vars.MKDOCS_APP_NAME }}" \
             --extra-vars "APP_TAG=${{ github.sha }} \
             --extra-vars "PROM_TAG=${{ vars.PROM_TAG }} \
-            --extra-vars "GRAFANA_TAG=${{ vars.GRAFANA_TAG }}
+            --extra-vars "GRAFANA_TAG=${{ vars.GRAFANA_TAG }} \
+            --extra-vars "GRAFANA_ADMIN_USER=${{ secrets.GF_SECURITY_ADMIN_USER }}" \
+            --extra-vars "GRAFANA_ADMIN_PASSWORD=${{ secrets.GF_SECURITY_ADMIN_PASSWORD }}" \
+            --extra-vars "GRAFANA_WORKDIR=/usr/share/grafana" \
+            --extra-vars "GRAFANA_PROVISIONING_PATH=conf/provisioning" \
+            --extra-vars "GRAFANA_RESET=${{ inputs.GRAFANA_RESET }}

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ OCI instance in this format:
     -----END RSA PRIVATE KEY-----
     ```
 
-
 Next, create Repository secrets named `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` and store your Dockerhub access token info.
 Additionally, create two more Github repository secrets named `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` and store
 your Cloudflare Service Auth token credentials. Also create a Github repository variables named `DOCKERHUB_ACCOUNT` and 
@@ -100,7 +99,8 @@ your Cloudflare Service Auth token credentials. Also create a Github repository 
 after the app. 
 
 Additionally, for Prometheus and Grafana support, create two additional variables `PROM_TAG` and `GRAFANA_TAG` with the
-dockerhub tags you wish to use for those two images.  
+dockerhub tags you wish to use for those two images. To set the initial admin credentials for Grafana, create two more 
+secrets named `GRAFANA_ADMIN_USER` and `GRAFANA_ADMIN_PASSWORD`. 
 
 #### Actions
 
@@ -120,3 +120,5 @@ Cloudflare (Tunnels/Applications/DNS)
 Mkdocs  
 Shell Scripting  
 Ansible
+Grafana
+Prometheus

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ Next, create Repository secrets named `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
 Additionally, create two more Github repository secrets named `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` and store
 your Cloudflare Service Auth token credentials. Also create a Github repository variables named `DOCKERHUB_ACCOUNT` and 
 `MKDOCS_APP_NAME` and store the name of your Dockerhub account and repository respectively. The repository should be named 
-after the app for consistency.  
+after the app. 
+
+Additionally, for Prometheus and Grafana support, create two additional variables `PROM_TAG` and `GRAFANA_TAG` with the
+dockerhub tags you wish to use for those two images.  
 
 #### Actions
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,10 +4,12 @@
 To run a playbook manually:
 
 ```shell
-ansible-playbook -i ansible/inventory/nodes.yml --limit node1 ansible/playbooks/deploy_prod.yml \
-  -e "IMAGE_TAG=${GITHUB_SHA}" \
+ansible-playbook -i ansible/inventory/nodes.yml --limit node1 ansible/playbooks/deploy.yml \
+  -e "APP_TAG=${GITHUB_SHA}" \
   -e "DOCKERHUB_ACCOUNT=${DOCKERHUB_ACCOUNT}" \
   -e "MKDOCS_APP_NAME=${MKDOCS_APP_NAME}" \
+  -e "PROM_TAG=${PROM_TAG}" \
+  -e "GRAFANA_TAG=${PROM_TAG}" \
   -e "CF_ACCESS_CLIENT_ID=${CF_ACCESS_CLIENT_ID}" \
   -e "CF_ACCESS_CLIENT_SECRET=${CF_ACCESS_CLIENT_SECRET}" \
   --private-key=~/.ssh/arm-k3s-oci"

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,14 +1,14 @@
 ---
-- name: Deploy Personal Site
-  gather_facts: no
-  hosts: mkdocs_nodes
-  roles:
-    - deploy-personal-site
+#- name: Deploy Personal Site
+#  gather_facts: no
+#  hosts: mkdocs_nodes
+#  roles:
+#    - deploy-personal-site
 
 - name: Deploy Monitoring
   gather_facts: no
   hosts: mkdocs_nodes
   roles:
-    - install-node-exporter
-    - deploy-prometheus
+#    - install-node-exporter
+#    - deploy-prometheus
     - deploy-grafana

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -4,3 +4,9 @@
   hosts: mkdocs_nodes
   roles:
     - deploy-personal-site
+
+- name: Deploy Prometheus
+  gather_facts: no
+  hosts: mkdocs_nodes
+  roles:
+    - deploy-prometheus

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -5,14 +5,10 @@
   roles:
     - deploy-personal-site
 
-- name: Deploy Prometheus
+- name: Deploy Monitoring
   gather_facts: no
   hosts: mkdocs_nodes
   roles:
+    - install-node-exporter
     - deploy-prometheus
-
-- name: Deploy Grafana
-  gather_facts: no
-  hosts: mkdocs_nodes
-  roles:
     - deploy-grafana

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -10,3 +10,9 @@
   hosts: mkdocs_nodes
   roles:
     - deploy-prometheus
+
+- name: Deploy Grafana
+  gather_facts: no
+  hosts: mkdocs_nodes
+  roles:
+    - deploy-grafana

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,14 +1,14 @@
 ---
-#- name: Deploy Personal Site
-#  gather_facts: no
-#  hosts: mkdocs_nodes
-#  roles:
-#    - deploy-personal-site
+- name: Deploy Personal Site
+  gather_facts: no
+  hosts: mkdocs_nodes
+  roles:
+    - deploy-personal-site
 
 - name: Deploy Monitoring
   gather_facts: no
   hosts: mkdocs_nodes
   roles:
-#    - install-node-exporter
-#    - deploy-prometheus
+    - install-node-exporter
+    - deploy-prometheus
     - deploy-grafana

--- a/ansible/playbooks/roles/deploy-grafana/README.md
+++ b/ansible/playbooks/roles/deploy-grafana/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible/playbooks/roles/deploy-grafana/files/system_metrics.json
+++ b/ansible/playbooks/roles/deploy-grafana/files/system_metrics.json
@@ -12,6 +12,12 @@
   "__elements": {},
   "__requires": [
     {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
@@ -53,6 +59,250 @@
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "minVizHeight": 200,
+        "minVizWidth": 200,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"})",
+          "instant": false,
+          "legendFormat": "Mountpoint \"/\"",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Utilization",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 4,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "minVizHeight": 200,
+        "minVizWidth": 200,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "irate(node_network_receive_bytes_total{device=\"ens3\"}[1m])",
+          "instant": false,
+          "legendFormat": "Receive",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "irate(node_network_transmit_bytes_total{device=\"ens3\"}[1m])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Transmit",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Network Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "avg without (mode,cpu) (1 - rate(node_cpu_seconds_total{mode=\"idle\"}[1m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization",
+      "type": "timeseries"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -116,7 +366,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 1,
       "options": {
@@ -173,6 +423,102 @@
       ],
       "title": "System Load",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "100 * (1 - ((avg_over_time(node_memory_MemFree_bytes[10m]) + avg_over_time(node_memory_Cached_bytes[10m]) + avg_over_time(node_memory_Buffers_bytes[10m])) / avg_over_time(node_memory_MemTotal_bytes[10m])))",
+          "instant": false,
+          "legendFormat": "System RAM",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Utilization",
+      "type": "timeseries"
     }
   ],
   "refresh": "",
@@ -182,7 +528,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},

--- a/ansible/playbooks/roles/deploy-grafana/files/system_metrics.json
+++ b/ansible/playbooks/roles/deploy-grafana/files/system_metrics.json
@@ -1,0 +1,194 @@
+{
+  "__inputs": [
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.2.3"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load1{instance=\"node1.tylerlee.dev:9100\",job=\"node_exporter\"}",
+          "instant": false,
+          "legendFormat": "Load1",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load5{instance=\"node1.tylerlee.dev:9100\",job=\"node_exporter\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Load5",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "node_load15{instance=\"node1.tylerlee.dev:9100\",job=\"node_exporter\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Load15",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "System Load",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "System Metrics",
+  "uid": "d74a022e-f577-4fc9-af75-8d9ccab692b8",
+  "version": 1,
+  "weekStart": ""
+}

--- a/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Stop and Remove Previous Container
-  ansible.builtin.shell: docker stop prometheus && docker rm prometheus
+  ansible.builtin.shell: docker stop grafana && docker rm grafana
   register: docker_stop
   timeout: 30
   ignore_errors: yes
 - debug: msg="{{ docker_stop.stdout_lines }}"
 
 - name: Start New Container
-  ansible.builtin.shell: docker run -d -p 8001:8001 --name prometheus prom/prometheus:{{ PROM_TAG }}
+  ansible.builtin.shell: docker run -d -p 8002:8002 --name grafana grafana/grafana:{{ GRAFANA_TAG }}
   register: start_container
   timeout: 180
 - debug: msg="{{ start_container.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
@@ -1,13 +1,67 @@
 ---
-- name: Stop and Remove Previous Container
+- name: Stop and Remove Previous Grafana Container
   ansible.builtin.shell: docker stop grafana && docker rm grafana
   register: docker_stop
   timeout: 30
   ignore_errors: yes
 - debug: msg="{{ docker_stop.stdout_lines }}"
 
-- name: Start New Container
-  ansible.builtin.shell: docker run -d -p 3000:3000 --name grafana grafana/grafana:{{ GRAFANA_TAG }}
+- name: Create Docker Network
+  ansible.builtin.shell: docker network create grafana-prometheus
+  register: create_network
+  timeout: 30
+  ignore_errors: yes
+- debug: msg="{{ create_network.stdout_lines }}"
+
+- name: Remove Grafana Volume
+  ansible.builtin.shell: docker volume rm grafana-storage
+  register: cleanup_volume
+  timeout: 30
+  when: 'GRAFANA_RESET == "true"'
+
+- name: Create directory to put files into
+  ansible.builtin.file:
+    path: '/home/{{ ansible_user }}/.grafana/dashboards'
+    state: directory
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: '0755'
+
+- name: Update Provisioning Files
+  ansible.builtin.template:
+    src: '{{ item }}'
+    dest: '/home/{{ansible_user}}/.grafana/'
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: '0644'
+    force: yes
+  loop:
+  - dashboards.yml
+  - datasources.yml
+
+- name: Update Dashboard
+  ansible.builtin.copy:
+    src: system_metrics.json
+    dest: /home/{{ ansible_user }}/.grafana/dashboards/system_metrics.json
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: '0644'
+
+- name: Start New Grafana Container
+  ansible.builtin.shell:
+    cmd: |
+      docker run -d -p 3000:3000 --name grafana \
+        --volume "grafana-storage:/var/lib/grafana" \
+        -v "/home/{{ ansible_user }}/.grafana/datasources.yml/:{{ GRAFANA_WORKDIR }}/{{ GRAFANA_PROVISIONING_PATH }}/datasources/datasources.yml" \
+        -v "/home/{{ ansible_user }}/.grafana/dashboards.yml/:{{ GRAFANA_WORKDIR }}/{{ GRAFANA_PROVISIONING_PATH }}/dashboards/dashboards.yml" \
+        -v "/home/{{ ansible_user }}/.grafana/dashboards/:/var/lib/grafana/dashboards/" \
+        --network grafana-prometheus \
+        -e "GF_SERVER_ROOT_URL=http://grafana.tylerlee.dev/" \
+        -e "GF_INSTALL_PLUGINS=grafana-clock-panel" \
+        -e "GF_SECURITY_ADMIN_USER={{ GRAFANA_ADMIN_USER }}" \
+        -e "GF_SECURITY_ADMIN_PASSWORD={{ GRAFANA_ADMIN_PASSWORD }}" \
+        -e "GF_PATHS_PROVISIONING={{ GRAFANA_PROVISIONING_PATH }}" \
+        grafana/grafana-oss:{{ GRAFANA_TAG }}
   register: start_container
   timeout: 180
 - debug: msg="{{ start_container.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-grafana/tasks/main.yml
@@ -7,7 +7,7 @@
 - debug: msg="{{ docker_stop.stdout_lines }}"
 
 - name: Start New Container
-  ansible.builtin.shell: docker run -d -p 8002:8002 --name grafana grafana/grafana:{{ GRAFANA_TAG }}
+  ansible.builtin.shell: docker run -d -p 3000:3000 --name grafana grafana/grafana:{{ GRAFANA_TAG }}
   register: start_container
   timeout: 180
 - debug: msg="{{ start_container.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-grafana/templates/dashboards.yml
+++ b/ansible/playbooks/roles/deploy-grafana/templates/dashboards.yml
@@ -1,0 +1,6 @@
+- name: 'default'
+  org_id: 1
+  folder: ''
+  type: 'file'
+  options:
+    folder: '/var/lib/grafana/dashboards'

--- a/ansible/playbooks/roles/deploy-grafana/templates/datasources.yml
+++ b/ansible/playbooks/roles/deploy-grafana/templates/datasources.yml
@@ -1,0 +1,9 @@
+datasources:
+- name: 'Prometheus'
+  type: 'prometheus'
+  access: 'proxy'
+  org_id: 1
+  url: 'http://prometheus:9090'
+  is_default: true
+  version: 1
+  editable: true

--- a/ansible/playbooks/roles/deploy-personal-site/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-personal-site/tasks/main.yml
@@ -7,7 +7,7 @@
 - debug: msg="{{ docker_stop.stdout_lines }}"
 
 - name: Start New Container
-  ansible.builtin.shell: docker run -d -p 8000:8000 --name {{ MKDOCS_APP_NAME }} {{ DOCKERHUB_ACCOUNT }}/{{ MKDOCS_APP_NAME }}:{{ IMAGE_TAG }}
+  ansible.builtin.shell: docker run -d -p 8000:8000 --name {{ MKDOCS_APP_NAME }} {{ DOCKERHUB_ACCOUNT }}/{{ MKDOCS_APP_NAME }}:{{ APP_TAG }}
   register: start_container
   timeout: 180
 - debug: msg="{{ start_container.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-prometheus/README.md
+++ b/ansible/playbooks/roles/deploy-prometheus/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
@@ -20,8 +20,15 @@
     dest: '/home/{{ansible_user}}/.prometheus/'
     owner: '{{ ansible_user }}'
     group: '{{ ansible_user }}'
-    mode: '0755'
+    mode: '0644'
     force: yes
+
+- name: Create Docker Network
+  ansible.builtin.shell: docker network create grafana-prometheus
+  register: create_network
+  timeout: 30
+  ignore_errors: yes
+- debug: msg="{{ create_network.stdout_lines }}"
 
 - name: Start New Container
   ansible.builtin.shell:
@@ -29,6 +36,7 @@
       docker run -d -p 9090:9090 \
         --name prometheus \
         --volume /home/{{ansible_user}}/.prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
+        --network grafana-prometheus \
         --entrypoint /bin/prometheus \
         prom/prometheus:{{ PROM_TAG }} \
         --config.file=/etc/prometheus/prometheus.yml \

--- a/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
@@ -1,2 +1,19 @@
 ---
-# tasks file for deploy-prometheus
+- name: Stop and Remove Previous Container
+  ansible.builtin.shell: docker stop prometheus && docker rm prometheus
+  register: docker_stop
+  timeout: 30
+  ignore_errors: yes
+- debug: msg="{{ docker_stop.stdout_lines }}"
+
+- name: Start New Container
+  ansible.builtin.shell: docker run -d -p 8001:8001 --name prometheus prom/prometheus:{{ IMAGE_TAG }}
+  register: start_container
+  timeout: 180
+- debug: msg="{{ start_container.stdout_lines }}"
+
+- name: List Docker Processes
+  ansible.builtin.shell: docker ps
+  register: docker_processes
+  timeout: 30
+- debug: msg="{{ docker_processes.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
@@ -6,8 +6,35 @@
   ignore_errors: yes
 - debug: msg="{{ docker_stop.stdout_lines }}"
 
+- name: Create directory to put files into
+  ansible.builtin.file:
+    path: '/home/{{ ansible_user }}/.prometheus/'
+    state: directory
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: '0755'
+
+- name: Update Prometheus Configuration
+  ansible.builtin.template:
+    src: 'prometheus.yml'
+    dest: '/home/{{ansible_user}}/.prometheus/'
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: '0755'
+    force: yes
+
 - name: Start New Container
-  ansible.builtin.shell: docker run -d -p 8001:8001 --name prometheus prom/prometheus:{{ PROM_TAG }}
+  ansible.builtin.shell:
+    cmd: |
+      docker run -d -p 9090:9090 \
+        --name prometheus \
+        --volume /home/{{ansible_user}}/.prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
+        --entrypoint /bin/prometheus \
+        prom/prometheus:{{ PROM_TAG }} \
+        --config.file=/etc/prometheus/prometheus.yml \
+        --storage.tsdb.path=/prometheus \
+        --web.console.libraries=/usr/share/prometheus/console_libraries \
+        --web.console.templates=/usr/share/prometheus/consoles
   register: start_container
   timeout: 180
 - debug: msg="{{ start_container.stdout_lines }}"

--- a/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
+++ b/ansible/playbooks/roles/deploy-prometheus/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for deploy-prometheus

--- a/ansible/playbooks/roles/deploy-prometheus/templates/prometheus.yml
+++ b/ansible/playbooks/roles/deploy-prometheus/templates/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: "node_exporter"
+    scrape_interval: 10s
+    static_configs:
+      - targets: ["node1.tylerlee.dev:9100"]

--- a/ansible/playbooks/roles/install-node-exporter/README.md
+++ b/ansible/playbooks/roles/install-node-exporter/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible/playbooks/roles/install-node-exporter/files/node_exporter.service
+++ b/ansible/playbooks/roles/install-node-exporter/files/node_exporter.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbooks/roles/install-node-exporter/tasks/configure.yml
+++ b/ansible/playbooks/roles/install-node-exporter/tasks/configure.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy service file
+  ansible.builtin.copy:
+    src: node_exporter.service
+    dest: /etc/systemd/system/node_exporter.service
+    owner: root
+    group: root
+    mode: '0644'

--- a/ansible/playbooks/roles/install-node-exporter/tasks/install.yml
+++ b/ansible/playbooks/roles/install-node-exporter/tasks/install.yml
@@ -1,0 +1,43 @@
+---
+- name: Create Node Exporter Group
+  ansible.builtin.group:
+    name: node_exporter
+    state: present
+
+- name: Create Node Exporter User
+  ansible.builtin.user:
+    name: node_exporter
+    groups: node_exporter
+    append: true
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+    home: /
+
+- name: Download Node Exporter
+  ansible.builtin.get_url:
+    url: "https://github.com/prometheus/node_exporter/releases/download/v1.7.0/node_exporter-1.7.0.linux-amd64.tar.gz"
+    dest: "/tmp/node_exporter-1.7.0.linux-amd64.tar.gz"
+    mode: '0644'
+
+- name: Decompress archive
+  become: true
+  ansible.builtin.unarchive:
+    src: "/tmp/node_exporter-1.7.0.linux-amd64.tar.gz"
+    dest: "/tmp"
+    creates: "/tmp/node_exporter-1.7.0.linux-amd64/node_exporter"
+    remote_src: true
+
+- name: Move binary to path
+  become: true
+  ansible.builtin.copy:
+    src: "/tmp/node_exporter-1.7.0.linux-amd64/node_exporter"
+    dest: "/usr/local/bin/node_exporter"
+    mode: 0755
+    owner: root
+    group: root
+    remote_src: true
+
+- name: Cleanup
+  become: true
+  ansible.builtin.shell: rm -r /tmp/node_exporter-1.7.0.linux-amd64*

--- a/ansible/playbooks/roles/install-node-exporter/tasks/main.yml
+++ b/ansible/playbooks/roles/install-node-exporter/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Install
+  ansible.builtin.include_tasks:
+    file: install.yml
+    apply:
+      become: true
+
+- name: Configure
+  ansible.builtin.include_tasks:
+    file: configure.yml
+    apply:
+      become: true
+
+- name: Start and enable service
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true
+    name: node_exporter
+    enabled: true
+    state: started

--- a/docs/observability/monitoring/README.md
+++ b/docs/observability/monitoring/README.md
@@ -1,0 +1,8 @@
+# Monitoring
+
+This website is monitored using Prometheus and Grafana and the dashboard is accessible here: [https://grafana.tylerlee.dev](https://grafana.tylerlee.dev)  
+
+
+Here is a historical snapshot:  
+<iframe width="100%" height="1700" src="https://snapshots.raintank.io/dashboard/snapshot/KBX6zae3EwVvLASrUwxX58OHlf1j7h2H"></iframe>
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ nav:
       'Docker': cheat-sheets/docker/README.md
       'Cloudflare': cheat-sheets/cloudflare/README.md
       'Misc': cheat-sheets/misc/README.md
+  - Observability:
+      'Monitoring': observability/monitoring/README.md
 theme:
   name: material
   features:


### PR DESCRIPTION
This feature adds Prometheus monitoring running in docker.

- New Ansible role for installing Node Exporter, Prometheus, Grafana
- Support deployment of Grafana dashboards and data sources from code
- Workflow dispatch now has a "Reset Grafana" toggle which will clear out the docker volume
- Embedded a snapshot of the grafana dashboard for viewing purposes since it isn't public